### PR TITLE
feat: deleteResume Route

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -1,24 +1,8 @@
-# from fastapi import FastAPI
-# from routes import resume_parser, skill_analysis, database
-
-# app = FastAPI(title="SkillBridge Backend")
-
-# # Routes
-# app.include_router(resume_parser.router, prefix="/api/v1")
-# app.include_router(skill_analysis.router, prefix="/api/v1")
-# app.include_router(database.router, prefix="/api/v1")
-
-# @app.get("/")
-# async def root():
-#     return {"message": "Welcome to SkillBridge API"}
-
-# if __name__ == "__main__":
-#     import uvicorn
-#     uvicorn.run(app, host="0.0.0.0", port=8000)
-
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routes import resume_parser, skill_analysis, database
+from fastapi.responses import RedirectResponse
+
 
 app = FastAPI(title="SkillBridge Backend")
 
@@ -36,9 +20,10 @@ app.include_router(resume_parser.router, prefix="/api/v1")
 app.include_router(skill_analysis.router, prefix="/api/v1")
 app.include_router(database.router, prefix="/api/v1")
 
-@app.get("/")
+
+@app.get("/", include_in_schema=False)
 async def root():
-    return {"message": "Welcome to SkillBridge API"}
+    return RedirectResponse(url="/docs")
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/app/backendDocs.md
+++ b/backend/app/backendDocs.md
@@ -16,9 +16,12 @@
 - URL
   ```bash
   http://localhost:8000/api/v1/process
+- Header
+  ```bash
+  user-id: '' // user-id of currently logged in user
 - Body Parameters -> form-data
   ```bash
-  Key: pdf_doc | Value: your pdf (from local)
+  Key: pdf_doc | Value: your pdf
 
 #### Post Request -- Skill Gap Analysis & Course Recommendation
 - URL
@@ -30,11 +33,8 @@
 - Body Parameters -> raw
   ```bash
   {
-    "resume_data": {
-       "Technical Skills": [], // Enter comma separated skills
-       "Soft Skills": [], // Enter comma separated skills
-  },
-  "job_description": "" // Enter description as plain text
+    "resume_id": "", // resume_id of the resume to analyze
+    "job_description": "" // Enter description as plain text
   }
 
 #### Get Request -- getResumeById
@@ -76,3 +76,22 @@
   http://localhost:8000/api/v1/getAllResumeById
   Header:
     user-id: 123456789
+
+#### Delete Request -- Deletes the resume pdf for a given reusme_id 
+- Deletes from following collections:
+  ```bash
+  GridFS file + chunks
+  Parsed resume
+  Skill analysis
+  Resume_ids array in Users collection
+- URL
+  ```bash
+  http://localhost:8000/api/v1/deleteResume/{resume_id}
+- Header
+  ```bash
+  user-id: {} // user-id to remove from users collection
+- Example
+  ```bash
+  http://localhost:8000/api/v1/deleteResume/67f18c459ab56ddc72fc2dba
+  Header:
+    user-id: user_2vCeDUx2obuFz0WEC5znYgH0ZLx


### PR DESCRIPTION
Added deleteResume route:
**/api/v1/deleteResume/{resume_id}**

Api takes:
- resume_id as part of the route
- user-id in the header

Deletes from following collections:
- GridFS file + chunks
- Parsed resume
- Skill analysis
- Resume_ids array in Users collection


Redirecting root route in backend to /docs for swagger 

Updated backend md.


Successfully tested delete:

<img width="1312" alt="deleteResume" src="https://github.com/user-attachments/assets/24a273c7-4be6-4b0c-9711-22c1e37550c7" />
